### PR TITLE
Refactor/recently updated filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,19 +222,19 @@ The website is built on our folder structure: adding a new folder will automatic
 ### Recently Updated Filter
 
 The home page shows a `Recently updated` filter when at least one character was
-updated for the latest changelog version.
+updated during either of the two latest changelog versions.
 
 The site reads [`src/content/site/changelog.json`](./src/content/site/changelog.json)
-and treats the first item in `groups` as the latest version. It compares that
-`version` value with each character folder's `metadata.json` `last_updated`
-value:
+and treats the first two items in `groups` as the recent versions. It compares
+those `version` values with each character folder's `metadata.json`
+`last_updated` value:
 
 ```txt
 src/content/<element>/<rarity>/<character>/metadata.json
 ```
 
 To make a character appear when this filter is checked, set `last_updated` to
-the same version as the first changelog group, for example:
+the same version as either of the first two changelog groups, for example:
 
 ```json
 {
@@ -244,7 +244,7 @@ the same version as the first changelog group, for example:
 
 The comparison trims extra spaces and normalizes spacing around `/`, but keep
 the written version consistent with the changelog. If no character matches the
-latest changelog version, the filter is hidden.
+two latest changelog versions, the filter is hidden.
 
 ---
 

--- a/content-guides/README.md
+++ b/content-guides/README.md
@@ -102,20 +102,20 @@ content loader, including:
 ## Recently Updated Home Filter
 
 The home page `Recently updated` filter is generated automatically from content
-data. The site reads `src/content/site/changelog.json`, uses the first item in
-`groups` as the latest changelog version, then compares that version with each
-character metadata file:
+data. The site reads `src/content/site/changelog.json`, uses the first two items
+in `groups` as the recent changelog versions, then compares those versions with
+each character metadata file:
 
 ```txt
 src/content/<element>/<rarity>/<character>/metadata.json
 ```
 
-A character appears in the filter when its `last_updated` value matches the
-latest changelog `version`. Extra spaces and spacing around `/` are normalized,
-so `6.6/Luna VII` and `6.6 / Luna VII` match, but contributors should still copy
-the version format from the changelog to avoid mistakes.
+A character appears in the filter when its `last_updated` value matches either
+of the two latest changelog versions. Extra spaces and spacing around `/` are
+normalized, so `6.6/Luna VII` and `6.6 / Luna VII` match, but contributors
+should still copy the version format from the changelog to avoid mistakes.
 
-If no character matches the latest changelog version, the filter is not shown.
+If no character matches either recent version, the filter is not shown.
 
 ## Section-Level Notes
 

--- a/content-guides/metadata.md
+++ b/content-guides/metadata.md
@@ -30,8 +30,8 @@ src/content/<element>/<rarity>/<character>/metadata.json
 - `last_updated`: Genshin version string shown in the page header and used by
   the home page `Recently updated` filter.
 - `version_released`: Character release version from the official HoYoWiki,
-  used by the home page `Version - Newest` sort. Use the changelog format for
-  Luna versions, such as `6.6 / Luna VII`.
+  used by the home page `Release date - Newest` sort. Use the changelog format
+  for Luna versions, such as `6.6 / Luna VII`.
 - `image`: Official fallback URL for the character splash art.
 - `portrait`: Official fallback URL for the small character icon used on the
   home page character list. Should come from the Hoyolab Battle Chronicles
@@ -39,11 +39,11 @@ src/content/<element>/<rarity>/<character>/metadata.json
 
 ## Recently Updated Filter
 
-The home page checks the latest version from the first `groups` item in
-`src/content/site/changelog.json`.
+The home page checks the two latest versions from the first two `groups` items
+in `src/content/site/changelog.json`.
 
 When a character should appear under the `Recently updated` filter, set
-`last_updated` to the same version:
+`last_updated` to either version:
 
 ```json
 {
@@ -53,9 +53,9 @@ When a character should appear under the `Recently updated` filter, set
 
 The comparison trims extra spaces and normalizes spacing around `/`. For
 clarity, still copy the version exactly as it appears in the changelog. If the
-value does not match the latest changelog version, the character remains visible
-in the normal roster but will not appear when the `Recently updated` filter is
-checked.
+value does not match either recent changelog version, the character remains
+visible in the normal roster but will not appear when the `Recently updated`
+filter is checked.
 
 ## Images
 

--- a/src/components/HomeFilters.astro
+++ b/src/components/HomeFilters.astro
@@ -1,7 +1,7 @@
 ---
 import { t } from '../utils/i18n';
 
-const { latestVersion = '', locale, recentlyUpdatedCount = 0 } = Astro.props;
+const { locale, recentlyUpdatedCount = 0 } = Astro.props;
 const hasRecentUpdates = recentlyUpdatedCount > 0;
 const recentlyUpdatedLabel = t(
   locale,
@@ -10,8 +10,7 @@ const recentlyUpdatedLabel = t(
   undefined,
   false,
 );
-const versionLabel = t(locale, 'ui', 'Version', undefined, false);
-const versionText = latestVersion ? `${versionLabel} ${latestVersion}` : '';
+const versionText = t(locale, 'ui', 'Last 2 versions', undefined, false);
 
 // Filter options mirror metadata values written onto each character card.
 const elements = ['anemo', 'cryo', 'dendro', 'electro', 'geo', 'hydro', 'pyro'];

--- a/src/i18n/en/ui.json
+++ b/src/i18n/en/ui.json
@@ -32,6 +32,7 @@
     "Sort by": "Sort by",
     "Newest": "Newest",
     "Release date": "Release date",
+    "Last 2 versions": "Last 2 versions",
     "Source": "Source",
     "Weapon source Craft": "Craft",
     "Weapon source Event": "Event",

--- a/src/i18n/fr/ui.json
+++ b/src/i18n/fr/ui.json
@@ -32,6 +32,7 @@
     "Sort by": "Trier Par",
     "Newest": "Plus récente",
     "Release date": "Date de sortie",
+    "Last 2 versions": "2 dernières versions",
     "Source": "Source",
     "Weapon source Craft": "Forge",
     "Weapon source Event": "Événement",

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -16,8 +16,9 @@ export const getStaticPaths = getLanguageStaticPaths;
 const requestedLang = Array.isArray(Astro.params.lang)
   ? Astro.params.lang[0]
   : Astro.params.lang;
-const { characters, lang, latestVersion, locale, recentlyUpdatedCharacters } =
-  getHomePageData(requestedLang ?? 'en');
+const { characters, lang, locale, recentlyUpdatedCharacters } = getHomePageData(
+  requestedLang ?? 'en',
+);
 ---
 
 <html lang={lang}>
@@ -36,7 +37,6 @@ const { characters, lang, latestVersion, locale, recentlyUpdatedCharacters } =
         {t(locale, 'ui', 'Home translation disclaimer', undefined, false)}
       </p>
       <HomeFilters
-        latestVersion={latestVersion}
         locale={locale}
         recentlyUpdatedCount={recentlyUpdatedCharacters.length}
       />

--- a/src/utils/home-page.ts
+++ b/src/utils/home-page.ts
@@ -19,16 +19,19 @@ function normalizeVersion(version: unknown) {
     : '';
 }
 
-function getLatestChangelogVersion(contentPath: string) {
+function getRecentChangelogVersions(contentPath: string) {
   const changelogPath = path.join(contentPath, 'site', 'changelog.json');
 
   if (!fs.existsSync(changelogPath)) {
-    return '';
+    return [];
   }
 
   const changelog = readJSONFile(changelogPath);
 
-  return normalizeVersion(changelog?.groups?.[0]?.version);
+  return (changelog?.groups ?? [])
+    .slice(0, 2)
+    .map((group: any) => normalizeVersion(group.version))
+    .filter(Boolean);
 }
 
 function getBuildSummaries(
@@ -65,7 +68,7 @@ export function getHomePageData(lang = 'en') {
   const locale = getLocale(lang);
   const contentPath = path.join(process.cwd(), 'src', 'content');
   const translator = new TranslationHelper(locale, {}, lang);
-  const latestVersion = getLatestChangelogVersion(contentPath);
+  const recentVersions = getRecentChangelogVersions(contentPath);
 
   const characters = getContentCharacters(contentPath)
     .map(({ character, characterPath, element, metadataPath, rarity }) => {
@@ -94,9 +97,7 @@ export function getHomePageData(lang = 'en') {
         weapon: metadata.weapon,
         lastUpdated,
         versionReleased,
-        isRecentlyUpdated: latestVersion
-          ? lastUpdated === latestVersion
-          : false,
+        isRecentlyUpdated: recentVersions.includes(lastUpdated),
         image: resolveCharacterAssetUrl(assetContext, metadata.image, 'image'),
         portrait: resolveCharacterAssetUrl(
           assetContext,
@@ -111,13 +112,13 @@ export function getHomePageData(lang = 'en') {
         a.element.localeCompare(b.element) || a.name.localeCompare(b.name),
     );
 
-  const recentlyUpdatedCharacters = latestVersion
-    ? characters.filter((character) => character.lastUpdated === latestVersion)
-    : [];
+  const recentlyUpdatedCharacters = characters.filter(
+    (character) => character.isRecentlyUpdated,
+  );
 
   return {
     characters,
-    latestVersion,
+    recentVersions,
     recentlyUpdatedCharacters,
     lang,
     locale,


### PR DESCRIPTION
## Summary

switch the recently updated filter to the last 2 versions so that changes made at the end of the version dont lose in visibility

## Checklist

- [x] The PR title follows the naming convention
- [x] I have linked the PR to the corresponding Issue if any
- [x] I have updated the changelog if needed
- [x] I have updated the "Last updated" metadata if needed

If you changed a note that was already translated / Added a new section that needs translating:
- [x] The necessary language tags are present on the PR
- [x] The old translations are removed
- [x] The translator notes section below tags the corresponding teams
- [x] The translator notes section below describes the changes that needs translation

## Translator notes

<!-- Use this section to explain what changed to the translators if necessary: what file, what item etc. You can ping the whole @\translator team if you're reworking the entire build and it needs new translation, or specific language teams like @\FR if only their translation needs some changes. -->
@Genshin-Impact-Helper-Team/it @Genshin-Impact-Helper-Team/ru : 1 new UI label in src\i18n\<lang>\ui.json
