### PR TITLE
fix 'heretics-molten-blade' EN note

### DIFF
--- a/src/content/cryo/5/odette/off-field-dps/weapons.json
+++ b/src/content/cryo/5/odette/off-field-dps/weapons.json
@@ -93,7 +93,7 @@
                 {
                     "name": "heretics-molten-blade",
                     "note": {
-                        "en": "This weapon's passive varies depending on your position relative to the enemy."
+                        "en": "This weapon's performance varies depending on distance traveled. Generally, [[character:odette]]'s [[ability:skill]] will move you enough for the passive to provide a solid effect. The [[stat:atk%]] buffing effect of this weapon will only apply to [[character:odette]]'s enhanced [[ability:skill]]."
                     }
                 }
             ]


### PR DESCRIPTION
Updated the description of the 'heretics-molten-blade' weapon to clarify its performance based on distance traveled.

## Summary

<!-- Briefly describe what changed and why. -->

## Checklist

- [x] The PR title follows the naming convention
- [x] I have linked the PR to the corresponding Issue if any
- [x] I have updated the changelog if needed
- [x] I have updated the "last_updated" metadata if needed (in metadata.json if all builds are up to date, in build-notes.json if only one is)
- [x] I have removed the "last_updated" from build-notes.json if all builds are up to date
- [x] I have removed the WIP notes from the build-notes.json files if I just updated a character
- [ ] The "Last Updated" metadata is "WIP" if the character's guide isn't ready yet

If you changed a note that was already translated / Added a new section that needs translating:

- [x] The necessary language tags are present on the PR
- [ ] The old translations are removed
- [ ] The translator notes section below tags the corresponding teams
- [ ] The translator notes section below describes the changes that needs translation

## Translator notes

<!-- Use this section to explain what changed to the translators if necessary: what file, what item etc.
You can ping the whole @\translator team if you're reworking the entire build and it needs new translation, or specific language teams like @\FR if only their translation needs some changes. -->
